### PR TITLE
Update screenorientation.ios.js

### DIFF
--- a/www/screenorientation.ios.js
+++ b/www/screenorientation.ios.js
@@ -11,25 +11,56 @@ module.exports = screenOrientation;
 window.shouldRotateToOrientation = function(orientation) {
     var currOrientation = cordova.plugins.screenorientation.currOrientation;
     switch (currOrientation) {
+
         case 'portrait':
+		
+			if (orientation === 0 || orientation === 180) return true;
+
+			break;
+
         case 'portrait-primary':
-            if (orientation === 0) return true;
-        break;
+
+           
+			if (orientation === 0) return true;
+
+			break;
+			
+		case 'portrait-secondary':
+
+           
+			if (orientation === 180) return true;
+
+			break;
+
         case 'landscape':
+
+                                               
+			if (orientation === -90 || orientation === 90) return true;
+
+														   
+			break;
+
         case 'landscape-primary':
-            if (orientation === -90) return true;
-        break;
-        case 'landscape':
+
+           
+			if (orientation === -90) return true;
+
+			break;
+
         case 'landscape-secondary':
-            if (orientation === 90) return true;
-        break;
-        case 'portrait':
-        case 'portrait-secondary':
-            if (orientation === 180) return true;
-        break;
+
+           
+			if (orientation === 90) return true;
+
+			break;
+
         default:
-            if (orientation === -90 || orientation === 90 || orientation === 0) return true;
-        break;
+
+           
+			if (orientation === -90 || orientation === 90 || orientation === 0) return true;
+
+			break;
+
     }
     return false;
 };


### PR DESCRIPTION
Hi, landscape doesn't work for primary and secondary base on the sensor. But if we over-write the function like this. It will work. Can you take a look and update this plugin? Thanks
