### PR TITLE
make iOS rotate as needed when lockOrientation is called

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,7 @@
         </js-module>
         <header-file src="src/ios/YoikScreenOrientation.h" />
         <source-file src="src/ios/YoikScreenOrientation.m" />
-        <source-file src="src/ios/CDVViewController+UpdateSupportedOrientations.h" />
+        <header-file src="src/ios/CDVViewController+UpdateSupportedOrientations.h" />
         <source-file src="src/ios/CDVViewController+UpdateSupportedOrientations.m" />
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,8 @@
         </js-module>
         <header-file src="src/ios/YoikScreenOrientation.h" />
         <source-file src="src/ios/YoikScreenOrientation.m" />
+        <source-file src="src/ios/CDVViewController+UpdateSupportedOrientations.h" />
+        <source-file src="src/ios/CDVViewController+UpdateSupportedOrientations.m" />
     </platform>
 
     <platform name="android">

--- a/src/ios/CDVViewController+UpdateSupportedOrientations.h
+++ b/src/ios/CDVViewController+UpdateSupportedOrientations.h
@@ -1,0 +1,31 @@
+/*
+ The MIT License (MIT)
+ 
+ Copyright (c) 2014
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#import <Cordova/CDVViewController.h>
+
+@interface CDVViewController (UpdateSupportedOrientations)
+
+- (void)updateSupportedOrientations:(NSArray *)orientations;
+
+@end

--- a/src/ios/CDVViewController+UpdateSupportedOrientations.m
+++ b/src/ios/CDVViewController+UpdateSupportedOrientations.m
@@ -1,0 +1,35 @@
+/*
+ The MIT License (MIT)
+ 
+ Copyright (c) 2014
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#import "CDVViewController+UpdateSupportedOrientations.h"
+
+@implementation CDVViewController (UpdateSupportedOrientations)
+
+- (void)updateSupportedOrientations:(NSArray *)orientations {
+	
+	[self setValue:orientations forKey:@"supportedOrientations"];
+
+}
+
+@end

--- a/src/ios/YoikScreenOrientation.h
+++ b/src/ios/YoikScreenOrientation.h
@@ -20,6 +20,7 @@
 */
 
 #import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVViewController.h>
 
 @interface YoikScreenOrientation : CDVPlugin
 

--- a/src/ios/YoikScreenOrientation.h
+++ b/src/ios/YoikScreenOrientation.h
@@ -25,6 +25,7 @@
 @interface YoikScreenOrientation : CDVPlugin
 
 - (void)screenOrientation:(CDVInvokedUrlCommand *)command;
+@property (strong, nonatomic) NSArray *originalSupportedOrientations;
 
 @end
 

--- a/src/ios/YoikScreenOrientation.m
+++ b/src/ios/YoikScreenOrientation.m
@@ -28,9 +28,19 @@
 {
     [self.commandDelegate runInBackground:^{
 
+        if(self.originalSupportedOrientations == nil) {
+            self.originalSupportedOrientations = [self.viewController valueForKey:@"supportedOrientations"];
+        }
+
         NSArray* arguments = command.arguments;
         NSString* orientationIn = [arguments objectAtIndex:1];
 
+        if ([orientationIn isEqual: @"unlocked"]) {
+            [(CDVViewController*)self.viewController updateSupportedOrientations:self.originalSupportedOrientations];
+            self.originalSupportedOrientations = nil;
+            return;
+        }
+        
         // grab the device orientation so we can pass it back to the js side.
         NSString *orientation;
         switch ([[UIDevice currentDevice] orientation]) {
@@ -49,10 +59,6 @@
             default:
                 orientation = @"portait";
                 break;
-        }
-
-        if ([orientationIn isEqual: @"unlocked"]) {
-            orientationIn = orientation;
         }
 
         // we send the result prior to the view controller presentation so that the JS side


### PR DESCRIPTION
Continue using ForceViewController approach but instead of immediately dismissing, first dynamically update supportedInterfaceOrientations on the main ViewController, then dismiss.
Only tested on iPhone 6 w/ iOS 9.2.1 so far.
