### PR TITLE
Allow orientation lock for browsers in fullscreen mode

### DIFF
--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -40,7 +40,9 @@ screenOrientation.currOrientation = 'unlocked';
 
 screenOrientation.setOrientation = function(orientation) {
     //platform specific files override this function
-    console.log('setOrientation not supported on device');
+    var fn = window.screen && window.screen.orientation && window.screen.orientation[orientation === 'unlocked' ? 'unlock' : 'lock'],
+        fs = document.fullscreenElement || document.webkitFullscreenElement || document.mozFullscreenElement || document.msFullscreenElement || document.oFullscreenElement;
+    return fs && fn && fn.call(window.screen.orientation, orientation) || console.log('setOrientation not supported on device');
 };
 
 function addScreenOrientationApi(screenObject) {


### PR DESCRIPTION
Some browsers can lock/unlock orientation when in fullscreen mode only - this simple change allows your API to still work in browsers as long as the needed functions are available and an element is currently fullscreen. I'd like to be able to handle this case without having to go around the plugin API and I don't see why anyone would object to having the option.