### PR TITLE
Fixing source path related to windows platform in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -83,7 +83,7 @@
     </platform>
 
     <platform name="windows">
-        <js-module src="www/screenOrientation.windows.js" name="screenorientation.windows">
+        <js-module src="www/screenorientation.windows.js" name="screenorientation.windows">
             <merges target="cordova.plugins.screenorientation" />
         </js-module>
     </platform>


### PR DESCRIPTION
While in the xml file it is named as screenOrientation.windows.js in the www folder its name is screenorientation.windows.js.

I figured this issue, when i had tried to fetch this plugin by intel XDK.
